### PR TITLE
fix missing disassembly ED 4F (LD R,A) and ED 5F (LD A,R)

### DIFF
--- a/z80_disassembler.cp
+++ b/z80_disassembler.cp
@@ -661,7 +661,7 @@ char            ireg[3];        // temp.Indexregister
                             break;
                         case 0x07:
                             {
-                            static const char *str[8] = {"LD\t\tI,A","???","LD\t\tA,I","???","RRD","RLD","???","???"};
+                            static const char *str[8] = {"LD\t\tI,A","LD\t\tR,A","LD\t\tA,I","LD\t\tA,R","RRD","RLD","???","???"};
                             strcpy(s,str[d]);
                             }
                             break;

--- a/z80_disassembler.cp
+++ b/z80_disassembler.cp
@@ -370,7 +370,8 @@ uint8_t         e = a & 7;
 static const char *reg[8] = {"B","C","D","E","H","L","(HL)","A"};
 static const char *dreg[4] = {"BC","DE","HL","SP"};
 static const char *cond[8] = {"NZ","Z","NC","C","PO","PE","P","M"};
-static const char *arith[8] = {"ADD\t\tA,","ADC\t\tA,","SUB\t\t","SBC\t\tA,","AND\t\t","XOR\t\t","OR\t\t","CP\t\t"};
+static const char *arith[8] = {"ADD     A,", "ADC     A, ", "SUB     ", "SBC     A,",
+                               "AND     ",   "XOR     ",    "OR      ", "CP      "};
 char            stemp[80];      // temp.String für sprintf()
 char            ireg[3];        // temp.Indexregister
 
@@ -383,18 +384,18 @@ char            ireg[3];        // temp.Indexregister
                 strcpy(s,"NOP");
                 break;
             case 0x01:
-                strcpy(s,"EX\t\tAF,AF'");
+                strcpy(s,"EX      AF,AF'");
                 break;
             case 0x02:
-                strcpy(s,"DJNZ\t");
+                strcpy(s,"DJNZ    ");
                 snprintf(stemp,sizeof(stemp),"%4.4Xh",adr+2+(uint8_t)Opcodes[adr+1]);strcat(s,stemp);
                 break;
             case 0x03:
-                strcpy(s,"JR\t\t");
+                strcpy(s,"JR      ");
                 snprintf(stemp,sizeof(stemp),"%4.4Xh",adr+2+(uint8_t)Opcodes[adr+1]);strcat(s,stemp);
                 break;
             default:
-                strcpy(s,"JR\t\t");
+                strcpy(s,"JR      ");
                 strcat(s,cond[d & 3]);
                 strcat(s,",");
                 snprintf(stemp,sizeof(stemp),"%4.4Xh",adr+2+(uint8_t)Opcodes[adr+1]);strcat(s,stemp);
@@ -403,10 +404,10 @@ char            ireg[3];        // temp.Indexregister
             break;
         case 0x01:
             if(a & 0x08) {
-                strcpy(s,"ADD\t\tHL,");
+                strcpy(s,"ADD     HL,");
                 strcat(s,dreg[d >> 1]);
             } else {
-                strcpy(s,"LD\t\t");
+                strcpy(s,"LD      ");
                 strcat(s,dreg[d >> 1]);
                 strcat(s,",");
                 snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
@@ -415,34 +416,34 @@ char            ireg[3];        // temp.Indexregister
         case 0x02:
             switch(d) {
             case 0x00:
-                strcpy(s,"LD\t\t(BC),A");
+                strcpy(s,"LD      (BC),A");
                 break;
             case 0x01:
-                strcpy(s,"LD\tA,(BC)");
+                strcpy(s,"LD      A,(BC)");
                 break;
             case 0x02:
-                strcpy(s,"LD\t\t(DE),A");
+                strcpy(s,"LD      (DE),A");
                 break;
             case 0x03:
-                strcpy(s,"LD\t\tA,(DE)");
+                strcpy(s,"LD      A,(DE)");
                 break;
             case 0x04:
-                strcpy(s,"LD\t\t(");
+                strcpy(s,"LD      (");
                 snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
                 strcat(s,"),HL");
                 break;
             case 0x05:
-                strcpy(s,"LD\t\tHL,(");
+                strcpy(s,"LD      HL,(");
                 snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
                 strcat(s,")");
                 break;
             case 0x06:
-                strcpy(s,"LD\t\t(");
+                strcpy(s,"LD      (");
                 snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
                 strcat(s,"),A");
                 break;
             case 0x07:
-                strcpy(s,"LD\t\tA,(");
+                strcpy(s,"LD      A,(");
                 snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
                 strcat(s,")");
                 break;
@@ -450,21 +451,21 @@ char            ireg[3];        // temp.Indexregister
             break;
         case 0x03:
             if(a & 0x08)
-                strcpy(s,"DEC\t\t");
+                strcpy(s,"DEC     ");
             else
-                strcpy(s,"INC\t\t");
+                strcpy(s,"INC     ");
             strcat(s,dreg[d >> 1]);
             break;
         case 0x04:
-            strcpy(s,"INC\t\t");
+            strcpy(s,"INC     ");
             strcat(s,reg[d]);
             break;
         case 0x05:
-            strcpy(s,"DEC\t\t");
+            strcpy(s,"DEC     ");
             strcat(s,reg[d]);
             break;
         case 0x06:              // LD   d,n
-            strcpy(s,"LD\t\t");
+            strcpy(s,"LD      ");
             strcat(s,reg[d]);
             strcat(s,",");
             snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
@@ -481,7 +482,7 @@ char            ireg[3];        // temp.Indexregister
         if(a == 0x76) {
             strcpy(s,"HALT");
         } else {
-            strcpy(s,"LD\t\t");
+            strcpy(s,"LD      ");
             strcat(s,reg[d]);
             strcat(s,",");
             strcat(s,reg[e]);
@@ -494,7 +495,7 @@ char            ireg[3];        // temp.Indexregister
     case 0xC0:
         switch(e) {
         case 0x00:
-            strcpy(s,"RET\t\t");
+            strcpy(s,"RET     ");
             strcat(s,cond[d]);
             break;
         case 0x01:
@@ -507,14 +508,14 @@ char            ireg[3];        // temp.Indexregister
                     strcpy(s,"EXX");
                     break;
                 case 0x02:
-                    strcpy(s,"JP\t\t(HL)");
+                    strcpy(s,"JP      (HL)");
                     break;
                 case 0x03:
-                    strcpy(s,"LD\t\tSP,HL");
+                    strcpy(s,"LD      SP,HL");
                     break;
                 }
             } else {
-                strcpy(s,"POP\t\t");
+                strcpy(s,"POP     ");
                 if((d >> 1)==3)
                     strcat(s,"AF");
                 else
@@ -522,7 +523,7 @@ char            ireg[3];        // temp.Indexregister
             }
             break;
         case 0x02:
-            strcpy(s,"JP\t\t");
+            strcpy(s,"JP      ");
             strcat(s,cond[d]);
             strcat(s,",");
             snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
@@ -530,7 +531,7 @@ char            ireg[3];        // temp.Indexregister
         case 0x03:
             switch(d) {
             case 0x00:
-                strcpy(s,"JP\t\t");
+                strcpy(s,"JP      ");
                 snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
                 break;
             case 0x01:                  // 0xCB
@@ -544,23 +545,23 @@ char            ireg[3];        // temp.Indexregister
                     static const char *str[8] = {"RLC","RRC","RL","RR","SLA","SRA","???","SRL"};
                     strcpy(s,str[d]);
                     }
-                    strcat(s,"\t\t");
+                    strcat(s,"     ");
                     strcat(s,reg[e]);
                     break;
                 case 0x40:
-                    strcpy(s,"BIT\t\t");
+                    strcpy(s,"BIT     ");
                     stemp[0] = d+'0';strcat(s,stemp);
                     strcat(s,",");
                     strcat(s,reg[e]);
                     break;
                 case 0x80:
-                    strcpy(s,"RES\t\t");
+                    strcpy(s,"RES     ");
                     stemp[0] = d+'0';strcat(s,stemp);
                     strcat(s,",");
                     strcat(s,reg[e]);
                     break;
                 case 0xC0:
-                    strcpy(s,"SET\t\t");
+                    strcpy(s,"SET     ");
                     stemp[0] = d+'0';strcat(s,stemp);
                     strcat(s,",");
                     strcat(s,reg[e]);
@@ -568,20 +569,20 @@ char            ireg[3];        // temp.Indexregister
                 }
                 break;
             case 0x02:
-                strcpy(s,"OUT\t\t(");
+                strcpy(s,"OUT     (");
                 snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                 strcat(s,"),A");
                 break;
             case 0x03:
-                strcpy(s,"IN\t\tA,(");
+                strcpy(s,"IN      A,(");
                 snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                 strcat(s,")");
                 break;
             case 0x04:
-                strcpy(s,"EX\t\t(SP),HL");
+                strcpy(s,"EX      (SP),HL");
                 break;
             case 0x05:
-                strcpy(s,"EX\t\tDE,HL");
+                strcpy(s,"EX      DE,HL");
                 break;
             case 0x06:
                 strcpy(s,"DI");
@@ -592,7 +593,7 @@ char            ireg[3];        // temp.Indexregister
             }
             break;
         case 0x04:
-            strcpy(s,"CALL\t");
+            strcpy(s,"CALL    ");
             strcat(s,cond[d]);
             strcat(s,",");
             snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
@@ -601,7 +602,7 @@ char            ireg[3];        // temp.Indexregister
             if(d & 1) {
                 switch(d >> 1) {
                 case 0x00:
-                    strcpy(s,"CALL\t");
+                    strcpy(s,"CALL    ");
                     snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
                     break;
                 case 0x02:              // 0xED
@@ -612,12 +613,12 @@ char            ireg[3];        // temp.Indexregister
                     case 0x40:
                         switch(e) {
                         case 0x00:
-                            strcpy(s,"IN\t\t");
+                            strcpy(s,"IN      ");
                             strcat(s,reg[d]);
                             strcat(s,",(C)");
                             break;
                         case 0x01:
-                            strcpy(s,"OUT\t\t(C),");
+                            strcpy(s,"OUT     (C),");
                             strcat(s,reg[d]);
                             break;
                         case 0x02:
@@ -625,18 +626,18 @@ char            ireg[3];        // temp.Indexregister
                                 strcpy(s,"ADC");
                             else
                                 strcpy(s,"SBC");
-                            strcat(s,"\t\tHL,");
+                            strcat(s,"     HL,");
                             strcat(s,dreg[d >> 1]);
                             break;
                         case 0x03:
                             if(d & 1) {
-                                strcpy(s,"LD\t\t");
+                                strcpy(s,"LD      ");
                                 strcat(s,dreg[d >> 1]);
                                 strcat(s,",(");
                                 snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
                                 strcat(s,")");
                             } else {
-                                strcpy(s,"LD\t\t(");
+                                strcpy(s,"LD      (");
                                 snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
                                 strcat(s,"),");
                                 strcat(s,dreg[d >> 1]);
@@ -655,13 +656,13 @@ char            ireg[3];        // temp.Indexregister
                             }
                             break;
                         case 0x06:
-                            strcpy(s,"IM\t\t");
+                            strcpy(s,"IM      ");
                             stemp[0] = d ? d + '0' - 1 : '0'; stemp[1] = 0;
                             strcat(s,stemp);
                             break;
                         case 0x07:
                             {
-                            static const char *str[8] = {"LD\t\tI,A","LD\t\tR,A","LD\t\tA,I","LD\t\tA,R","RRD","RLD","???","???"};
+                            static const char *str[8] = {"LD      I,A","LD      R,A","LD      A,I","LD      A,R","RRD","RLD","???","???"};
                             strcpy(s,str[d]);
                             }
                             break;
@@ -683,64 +684,64 @@ char            ireg[3];        // temp.Indexregister
                     a = Opcodes[++adr]; // Erweiterungsopcode holen
                     switch(a) {
                     case 0x09:
-                        strcpy(s,"ADD\t\t");
+                        strcpy(s,"ADD     ");
                         strcat(s,ireg);
                         strcat(s,",BC");
                         break;
                     case 0x19:
-                        strcpy(s,"ADD\t\t");
+                        strcpy(s,"ADD     ");
                         strcat(s,ireg);
                         strcat(s,",DE");
                         break;
                     case 0x21:
-                        strcpy(s,"LD\t\t");
+                        strcpy(s,"LD      ");
                         strcat(s,ireg);
                         strcat(s,",");
                         snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
                         break;
                     case 0x22:
-                        strcpy(s,"LD\t\t(");
+                        strcpy(s,"LD      (");
                         snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
                         strcat(s,"),");
                         strcat(s,ireg);
                         break;
                     case 0x23:
-                        strcpy(s,"INC\t\t");
+                        strcpy(s,"INC     ");
                         strcat(s,ireg);
                         break;
                     case 0x29:
-                        strcpy(s,"ADD\t\t");
+                        strcpy(s,"ADD     ");
                         strcat(s,ireg);
                         strcat(s,",");
                         strcat(s,ireg);
                         break;
                     case 0x2A:
-                        strcpy(s,"LD\t\t");
+                        strcpy(s,"LD      ");
                         strcat(s,ireg);
                         strcat(s,",(");
                         snprintf(stemp,sizeof(stemp),"%4.4Xh",Opcodes[adr+1]+(Opcodes[adr+2]<<8));strcat(s,stemp);
                         strcat(s,")");
                         break;
                     case 0x2B:
-                        strcpy(s,"DEC\t\t");
+                        strcpy(s,"DEC     ");
                         strcat(s,ireg);
                         break;
                     case 0x34:
-                        strcpy(s,"INC\t\t(");
+                        strcpy(s,"INC     (");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                         strcat(s,")");
                         break;
                     case 0x35:
-                        strcpy(s,"DEC\t\t(");
+                        strcpy(s,"DEC     (");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                         strcat(s,")");
                         break;
                     case 0x36:
-                        strcpy(s,"LD\t\t(");
+                        strcpy(s,"LD      (");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
@@ -748,7 +749,7 @@ char            ireg[3];        // temp.Indexregister
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+2]);strcat(s,stemp);
                         break;
                     case 0x39:
-                        strcpy(s,"ADD\t\t");
+                        strcpy(s,"ADD     ");
                         strcat(s,ireg);
                         strcat(s,",SP");
                         break;
@@ -758,7 +759,7 @@ char            ireg[3];        // temp.Indexregister
                     case 0x5E:
                     case 0x66:
                     case 0x6E:
-                        strcpy(s,"LD\t\t");
+                        strcpy(s,"LD      ");
                         strcat(s,reg[(a>>3)&7]);
                         strcat(s,",(");
                         strcat(s,ireg);
@@ -773,7 +774,7 @@ char            ireg[3];        // temp.Indexregister
                     case 0x74:
                     case 0x75:
                     case 0x77:
-                        strcpy(s,"LD\t\t(");
+                        strcpy(s,"LD      (");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
@@ -781,87 +782,87 @@ char            ireg[3];        // temp.Indexregister
                         strcat(s,reg[a & 7]);
                         break;
                     case 0x7E:
-                        strcpy(s,"LD\t\tA,(");
+                        strcpy(s,"LD      A,(");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                         strcat(s,")");
                         break;
                     case 0x86:
-                        strcpy(s,"ADD\t\tA,(");
+                        strcpy(s,"ADD     A,(");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                         strcat(s,")");
                         break;
                     case 0x8E:
-                        strcpy(s,"ADC\t\tA,(");
+                        strcpy(s,"ADC     A,(");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                         strcat(s,")");
                         break;
                     case 0x96:
-                        strcpy(s,"SUB\t\t(");
+                        strcpy(s,"SUB     (");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                         strcat(s,")");
                         break;
                     case 0x9E:
-                        strcpy(s,"SBC\t\tA,(");
+                        strcpy(s,"SBC     A,(");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                         strcat(s,")");
                         break;
                     case 0xA6:
-                        strcpy(s,"AND\t\tA,(");
+                        strcpy(s,"AND     A,(");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                         strcat(s,")");
                         break;
                     case 0xAE:
-                        strcpy(s,"XOR\t\tA,(");
+                        strcpy(s,"XOR     A,(");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                         strcat(s,")");
                         break;
                     case 0xB6:
-                        strcpy(s,"OR\t\tA,(");
+                        strcpy(s,"OR      A,(");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                         strcat(s,")");
                         break;
                     case 0xBE:
-                        strcpy(s,"CP\t\tA,(");
+                        strcpy(s,"CP      A,(");
                         strcat(s,ireg);
                         strcat(s,"+");
                         snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
                         strcat(s,")");
                         break;
                     case 0xE1:
-                        strcpy(s,"POP\t\t");
+                        strcpy(s,"POP     ");
                         strcat(s,ireg);
                         break;
                     case 0xE3:
-                        strcpy(s,"EX\t\t(SP),");
+                        strcpy(s,"EX      (SP),");
                         strcat(s,ireg);
                         break;
                     case 0xE5:
-                        strcpy(s,"PUSH\t");
+                        strcpy(s,"PUSH    ");
                         strcat(s,ireg);
                         break;
                     case 0xE9:
-                        strcpy(s,"JP\t\t(");
+                        strcpy(s,"JP      (");
                         strcat(s,ireg);
                         strcat(s,")");
                         break;
                     case 0xF9:
-                        strcpy(s,"LD\t\tSP,");
+                        strcpy(s,"LD      SP,");
                         strcat(s,ireg);
                         break;
                     case 0xCB:
@@ -874,22 +875,22 @@ char            ireg[3];        // temp.Indexregister
                             static const char *str[8] = {"RLC","RRC","RL","RR","SLA","SRA","???","SRL"};
                             strcpy(s,str[d]);
                             }
-                            strcat(s,"\t\t");
+                            strcat(s,"     ");
                             break;
                         case 0x40:
-                            strcpy(s,"BIT\t\t");
+                            strcpy(s,"BIT     ");
                             stemp[0] = d + '0';
                             strcat(s,stemp);
                             strcat(s,",");
                             break;
                         case 0x80:
-                            strcpy(s,"RES\t\t");
+                            strcpy(s,"RES     ");
                             stemp[0] = d + '0';
                             strcat(s,stemp);
                             strcat(s,",");
                             break;
                         case 0xC0:
-                            strcpy(s,"SET\t\t");
+                            strcpy(s,"SET     ");
                             stemp[0] = d + '0';
                             strcat(s,stemp);
                             strcat(s,",");
@@ -905,7 +906,7 @@ char            ireg[3];        // temp.Indexregister
                     break;
                 }
             } else {
-                strcpy(s,"PUSH\t");
+                strcpy(s,"PUSH    ");
                 if((d >> 1)==3)
                     strcat(s,"AF");
                 else
@@ -917,7 +918,7 @@ char            ireg[3];        // temp.Indexregister
             snprintf(stemp,sizeof(stemp),"%2.2Xh",Opcodes[adr+1]);strcat(s,stemp);
             break;
         case 0x07:
-            strcpy(s,"RST\t\t");
+            strcpy(s,"RST     ");
             snprintf(stemp,sizeof(stemp),"%2.2Xh",a & 0x38);strcat(s,stemp);
             break;
         }
@@ -987,7 +988,7 @@ char     s[80];          // Ausgabestring
         int16_t len,i;
 
         if((OpcodesFlags[adr] & 0x0F) == Data) {
-            fprintf(f,"L%4.4X:\tDEFB",(uint16_t)adr);
+            fprintf(f,"L%4.4X:  DEFB",(uint16_t)adr);
             for(i=0;i<16;i++) {
                 if((OpcodesFlags[adr+i] & 0x0F) != Data) break;
                 fprintf(f,"%c%2.2Xh",(i)?',':' ',Opcodes[adr+i]);
@@ -998,9 +999,9 @@ char     s[80];          // Ausgabestring
             len = OpcodeLen(adr);           // Länge vom Opcode ermitteln
 #if 1
             if(OpcodesFlags[adr] & 0x10)
-                fprintf(f,"L%4.4X:\t",adr);
+                fprintf(f,"L%4.4X:  ",adr);
             else
-                fprintf(f,"\t\t");
+                fprintf(f,"        ");
 #else
             fprintf(f,"%4.4X: ",(uint16_t)adr);
             for(i=0;i<len;i++)

--- a/z80_tokenize.cp
+++ b/z80_tokenize.cp
@@ -19,8 +19,11 @@ typedef struct {
     uint16_t   p;          // Parameter
 } ShortSym;
 
-static const ShortSym    Pseudo[] = {    { 0x100,"DEFB",0x0000}, { 0x101,"DEFM",0x0000},{ 0x102,"DEFS",0x0000},
-                            { 0x103,"DEFW",0x0000}, { 0x109,"ELSE",0x0000},{ 0x104,"END",0x0000},
+static const ShortSym    Pseudo[] = {    { 0x100,"DEFB",0x0000}, { 0x100,"DB",0x0000},
+                            { 0x101,"DEFM",0x0000}, { 0x101,"DM",0x0000},
+                            { 0x102,"DEFS",0x0000}, { 0x102,"DS",0x0000},
+                            { 0x103,"DEFW",0x0000}, { 0x103,"DW",0x0000},
+                            { 0x109,"ELSE",0x0000}, { 0x104,"END",0x0000},
                             { 0x108,"ENDIF",0x0000},{ 0x105,"EQU",0x0000}, { 0x107,"IF",0x0000},
                             { 0x106,"ORG",0x0000},  { 0x10A,"PRINT",0x0000} };
 // Typ: (+ 0x200)


### PR DESCRIPTION
- fix missing disassembly `ED 4F` (`LD R,A`) and `ED 5F` (`LD A,R`)
- assembler enhancement: `DB`, `DM`, `DS`, `DW` short for `DEFB`, `DEFM`, `DEFS`, `DEFW`
- replace tab (width=4) by spaces -> consistent indentation in all editors