### PR TITLE
fix #13, detect wrong [adc sbc] ix/iy,[bc de ix/iy sp]

### DIFF
--- a/z80_compile.cp
+++ b/z80_compile.cp
@@ -209,6 +209,8 @@ RecalcListP op1Recalc,op2Recalc;
                     break;
                 case 0x330: // IX
                 case 0x331: // IY
+                    if ( Op0_24 != 0x80 ) // only ADD IX/IY,RR
+                        Error("Only ADD IX,[BC,DE,IX,SP] or ADD IY,[BC,DE,IY,SP] are possible");
                     switch(op2) {
                     case 0x310: // BC
                         *iRAM++ = (op1 & 0x01)?0xFD:0xDD;


### PR DESCRIPTION
```
$ ./z80assembler
TurboAss Z80 - a small 1-pass assembler for Z80 code
(c)1992/3 Sigma-Soft, Markus Fritze

Error in line 15: Only ADD IX,[BC,DE,IX,SP] or ADD IY,[BC,DE,IY,SP] are possible
sbc ix,bc   ; error, this code does not exist
```