### PR TITLE
increase compatibility

### DIFF
--- a/z80_assembler.cpp
+++ b/z80_assembler.cpp
@@ -82,9 +82,8 @@ int main( int argc, char **argv ) {
     bool no_outfile = false;
 
 
-    puts( "TurboAss Z80 - a small 1-pass assembler for Z80 code" );
-    puts( "(c)1992/3 Sigma-Soft, Markus Fritze" );
-    puts( "" );
+    fprintf( stderr, "TurboAss Z80 - a small 1-pass assembler for Z80 code\n" );
+    fprintf( stderr, "(c)1992/3 Sigma-Soft, Markus Fritze\n\n" );
 
 
     for ( i = 1, j = 0; i < argc; i++ ) {

--- a/z80_assembler.h
+++ b/z80_assembler.h
@@ -51,6 +51,7 @@ extern const uint32_t RAMSIZE;
 extern uint32_t minPC;
 extern uint32_t maxPC;
 extern bool listing;
+extern int verboseMode;
 extern void checkPC( uint32_t pc );
 
 extern RecalcListP LastRecalc; // to patch the type for incomplete formulas


### PR DESCRIPTION
- pseudo ops can start with dot, e.g. `.org`
- `defb` and `defm` can mix numbers and strings, e.g. `defm "hello", 0x0D, 0x0A`
- add undoc opcodes `out (c),0` and `in (c)`