### PR TITLE
Add c array output file and listing output file 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# edit backups
+*~
+.*~
+
+# work files
+*.asm
+*.bin
+*.com
+*.hex
+*.z80
+
+# object files
+*.o
+
+# binaries
+z80assembler
+z80disassembler

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ z80disassembler: z80_disassembler.o kk_ihex_read.o
 	$(CC) -o $@ $^ $(CFLAGS)
 
 clean:
-	rm -f *.o
+	rm -f *.o *~

--- a/z80_compile.cpp
+++ b/z80_compile.cpp
@@ -898,13 +898,16 @@ void DoPseudo( CommandP *cp ) {
             }
         } while ( ( c->typ == OPCODE ) && ( c->val == ',' ) );
         break;
-    case DEFS:
+    case DEFS: {
         cptr = c;
-        iPC += CalcTerm( &cptr ); // advance the PC
+        uint16_t size = CalcTerm( &cptr ); // get the amount
+        checkPC( iPC + size - 1 ); // guard against overflow
+        iPC += size; // advance the PC
         c = cptr;
         if ( LastRecalc )
             Error( "symbol not defined" );
         break;
+    }
     case FILL: {
         uint16_t size, fill = 0;
         cptr = c;


### PR DESCRIPTION
Hi Markus,
for my [Z80-MBC2 project](https://github.com/Ho-Ro/Z80-MBC2) I needed an uint8_t array with the Z80 binary, so I added this output format.
Also a listing file is now available.
I skipped the strange *.z80 output format, *.z80 is now a valid input (like *.asm).
Martin

Usage: z80assembler [-b] [-i] [-fXX] [-l] [-oXXXX] [-v] INFILE
  -b       create binary output file
  -c       create C array output file
  -i       create intel hex output file
  -fXX     fill ram with byte XX (default: 00)
  -l       create listing file
  -oXXXX   offset address = 0x0000 .. 0xFFFF
  -v       increase verbosity